### PR TITLE
Implement cancel_reason for QueryTxnStatusResponse objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Added
+- Added `cancel_reason` for `QueryTxnStatusResponse` so that developers could use this to describe cancelled transactions
+
 ## [1.0.1] - 2017-02-16
 ### Fixed
 - Fixed logging of sensitive information

--- a/lib/e_way_client/responses/query_txn_status_response.rb
+++ b/lib/e_way_client/responses/query_txn_status_response.rb
@@ -11,10 +11,14 @@ module EWayClient
       lazy: true,
       default: :default_error_message,
     })
-    attribute :transaction_status, String, {
+    attribute(:transaction_status, String, {
       lazy: true,
       default: :default_transaction_status,
-    }
+    })
+    attribute(:cancel_reason, String, {
+      lazy: true,
+      default: :default_cancel_reason,
+    })
 
     private
 
@@ -32,6 +36,10 @@ module EWayClient
 
     def default_transaction_status
       data[:transaction_status]
+    end
+
+    def default_cancel_reason
+      data[:cancel_reason]
     end
 
   end


### PR DESCRIPTION
Fetching the `cancel_reason` attribute on the responses would be used to fetch the description for cancelled transactions